### PR TITLE
change scipy to gmpy2 factorial which is faster

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,17 @@
 from skbuild import setup
 
-cmake_args = ["-Dpython:BOOL=ON", "-Dopenmp:BOOL=OFF", "-Dtests:BOOL=OFF",
-              "-Dconan_fftw=ON"]
+cmake_args = [
+    "-Dpython:BOOL=ON",
+    "-Dopenmp:BOOL=OFF",
+    "-Dtests:BOOL=OFF",
+    "-Dconan_fftw=ON",
+]
 
 setup(
     name="pyssht",
     version="2.0",
     author="Jason McEwen",
-    install_requires=["numpy", "cython", "scipy"],
+    install_requires=["numpy", "cython", "gmpy2"],
     extras_require={
         "dev": [
             "setuptools",
@@ -16,7 +20,7 @@ setup(
             "cmake",
             "ninja",
             "cython",
-            "conan"
+            "conan",
         ]
     },
     description="Fast spin spherical transforms",

--- a/src/pyssht/pyssht.pyx
+++ b/src/pyssht/pyssht.pyx
@@ -5,7 +5,7 @@ import numpy as np
 cimport numpy as np
 
 from libc.math cimport log, exp
-from scipy.special import factorial
+from gmpy2 import factorial
 
 #----------------------------------------------------------------------------------------------------#
 


### PR DESCRIPTION
When generating the spherical harmonics for all alpha, beta it is very slow but a bit better with `gmpy2`. It is still slow but better than before.

```
import pyssht as ssht
L = 32
t, p = ssht.sample_positions(L, Grid=True, Method="MWSS")
ylm = ssht.create_ylm(t, p, L)
```


