### PR TITLE
Compile against oldest possible numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools", "wheel", "scikit-build", "cmake>=3.12", "ninja", "cython",
-    "numpy", "conan"
+    "oldest-supported-numpy", "conan"
 ]
 
 [tool.isort]


### PR DESCRIPTION
It avoids binary incompatibilities.

Closes #47