### PR TITLE
Draft: add ducc support for forward adjoint

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -118,14 +118,14 @@ jobs:
           mv source-distribution/*.tar.gz  wheel-*/*.whl dist
 
       - name: Publish distribution 📦 to Test PyPI
-        if: ${{ github.ref != 'refs/tags/v1.4.0' }}
+        if: ${{ github.ref != 'refs/tags/v1.5.0' }}
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
 
       - name: Publish distribution 📦 to PyPI
-        if: ${{ github.ref == 'refs/tags/v1.4.0' }}
+        if: ${{ github.ref == 'refs/tags/v1.5.0' }}
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.PYPI_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(
     Ssht
-    VERSION "1.4.0"
+    VERSION "1.5.0"
     DESCRIPTION "Fast and exact spin spherical harmonic transforms"
     HOMEPAGE_URL "http://astro-informatics.github.io/ssht/"
     LANGUAGES C)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ spin spherical harmonic transforms based on the sampling theorem on the
 sphere derived in <a href="http://www.jasonmcewen.org/publication/mcewen-fssht/">McEwen & Wiaux (2011)</a>.
 
 **SSHT** can also interface with [ducc0](https://pypi.org/project/ducc0/) and
-*use it as a backend for the forward, inverse and inverse adjoint transforms.
+use it as a backend for spherical harmonic transforms and rotations.
 
 
 ## INSTALLATION

--- a/docs/index.html
+++ b/docs/index.html
@@ -52,6 +52,8 @@ harmonics, sphere, transforms, fourier, fast, algorithms, mcewen, wiaux" />
       <ul>
 
         <li><strong>July 2021</strong><br />
+          Release of SSHT 1.5.0 (<a href="https://pypi.org/project/ducc0/">ducc0</a> forward adjoint)
+        <li><strong>July 2021</strong><br />
           Release of SSHT 1.4.0 (<a href="https://pypi.org/project/ducc0/">ducc0</a>interface)
         <li><strong>February 2021</strong><br />
           Release of SSHT 1.3.7 (<a href="https://conan.io/center/ssht">conan-center</a>release)

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 # ======== COMPILER ========
 
 CC      = gcc
-OPT		= -std=c99 -pedantic -Wall -O3 -fopenmp -DSSHT_VERSION=\"1.4.0\" -DSSHT_BUILD=\"`git rev-parse HEAD`\"
+OPT		= -std=c99 -pedantic -Wall -O3 -fopenmp -DSSHT_VERSION=\"1.5.0\" -DSSHT_BUILD=\"`git rev-parse HEAD`\"
 #OPT	= -Wall -g -fopenmp -DSSHT_VERSION=\"1.0b1\" -DSSHT_BUILD=\"`git rev-parse HEAD`\"
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.0
+current_version = 1.5.0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<rc>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ dev_requirements = [
     "conan",
     "pip!=20.0.0,!=20.0.1",
     "pytest",
-    "ducc0>=0.16",
+    "ducc0>=0.18",
 ]
 
 long_description = (
@@ -36,7 +36,7 @@ setup(
         "Y. Wiaux",
     ],
     install_requires=["numpy", "scipy"],
-    extras_require={"dev": dev_requirements, "ducc0": ["ducc0>=0.16"]},
+    extras_require={"dev": dev_requirements, "ducc0": ["ducc0>=0.18"]},
     description="Fast spin spherical transforms",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ long_description = (
 
 setup(
     name="pyssht",
-    version="1.4.0",
+    version="1.5.0",
     author=[
         "J. D. McEwen",
         "C. R. G. Wallis",

--- a/src/pyssht/SSHT_Python_Documentation.md
+++ b/src/pyssht/SSHT_Python_Documentation.md
@@ -98,6 +98,10 @@ Performs the adjoint of the forward spherical harmonic transform.
     1. `'MW'`         [McEwen & Wiaux sampling (default)]
     2. `'MWSS'`       [McEwen & Wiaux symmetric sampling]
 * `Reality`  determines if the signal is real or complex, Boolean (default = False)
+* `backend` the backend that runs the transforms:
+    1. `'SSHT'` this package
+    2. `'ducc'` interface to [ducc0](https://pypi.org/project/ducc0/).
+* `nthreads`: number of threads when calling into the `'ducc'` backend. Ignored otherwise.
 
 #### Output
 
@@ -122,8 +126,7 @@ Performs the adjoint of the inverse spherical harmonic transform.
 * `Reality`  determines if the signal is real or complex, Boolean (default = False)
 * `backend` the backend that runs the transforms:
     1. `'SSHT'` this package
-    2. `'ducc'` interface to [ducc0](https://pypi.org/project/ducc0/). "MW_pole"
-       is not available in this backend.
+    2. `'ducc'` interface to [ducc0](https://pypi.org/project/ducc0/).
 * `nthreads`: number of threads when calling into the `'ducc'` backend. Ignored otherwise.
 
 #### Output

--- a/src/pyssht/cpyssht.pyx
+++ b/src/pyssht/cpyssht.pyx
@@ -612,10 +612,14 @@ def inverse_adjoint(f, int L, int Spin=0, str Method='MW', bint Reality=False, s
     return flm
 
 
-def forward_adjoint(flm, int L, int Spin=0, str Method='MW', bint Reality=False, str backend="SSHT"):
-    from pyssht.parameters import method
+def forward_adjoint(flm, int L, int Spin=0, str Method='MW', bint Reality=False, str backend="SSHT", **kwargs):
+    from pyssht.ducc_interface import forward_adjoint as _ducc0_forward_adjoint
+    from pyssht.parameters import method, Ducc
 
     params = method(Method, spin=Spin, reality=Reality, backend=backend)
+
+    if isinstance(params, Ducc):
+        return _ducc0_forward_adjoint(flm, L, params.spin, params.method, params.reality, params.nthreads)
 
     if flm.ndim != 1:
       raise ssht_input_error('flm must be 1D numpy array')

--- a/tests/test_ducc0.py
+++ b/tests/test_ducc0.py
@@ -3,7 +3,7 @@ from pytest import approx, fixture, mark, importorskip
 
 import pyssht as ssht
 
-skip_ducc0 = importorskip("ducc0", minversion="0.16")
+skip_ducc0 = importorskip("ducc0", minversion="0.18")
 
 
 @fixture

--- a/tests/test_ducc0.py
+++ b/tests/test_ducc0.py
@@ -100,6 +100,26 @@ def test_real_inverse_adjoint_ssht_vs_ducc0(real_image, order, method, nthreads=
     assert ssht_adj_coeffs == approx(ducc0_adj_coeffs)
 
 
+def test_real_forward_adjoint_ssht_vs_ducc0(real_coeffs, order, method, nthreads=1):
+    from pyssht.exceptions import ssht_input_error
+
+    try:
+        ssht_image = ssht.forward_adjoint(real_coeffs, order, Reality=True, Method=method, Spin=0)
+    except ssht_input_error:
+        assert method not in ("MW", "MWSS")
+        return
+    ducc0_image = ssht.forward_adjoint(
+        real_coeffs,
+        order,
+        Reality=True,
+        Method=method,
+        Spin=0,
+        backend="ducc",
+        nthreads=nthreads,
+    )
+    assert ssht_image[1:-1] == approx(ducc0_image[1:-1])
+
+
 def test_complex_inverse_ssht_vs_ducc0(complex_coeffs, order, method, spin, nthreads=1):
     ssht_image = ssht.inverse(
         complex_coeffs, order, Reality=False, Method=method, Spin=spin
@@ -155,6 +175,28 @@ def test_complex_inverse_adjoint_ssht_vs_ducc0(
         nthreads=nthreads,
     )
     assert ssht_adj_coeffs == approx(ducc0_adj_coeffs)
+
+
+def test_complex_forward_adjoint_ssht_vs_ducc0(complex_coeffs, order, method, spin, nthreads=1):
+    from pyssht.exceptions import ssht_input_error
+
+    try:
+        ssht_image = ssht.forward_adjoint(
+            complex_coeffs, order, Reality=False, Method=method, Spin=spin
+    )
+    except ssht_input_error:
+        assert method not in ("MW", "MWSS")
+        return
+    ducc0_image = ssht.forward_adjoint(
+        complex_coeffs,
+        order,
+        Reality=False,
+        Method=method,
+        Spin=spin,
+        backend="ducc",
+        nthreads=nthreads,
+    )
+    assert ssht_image[1:-1] == approx(ducc0_image[1:-1])
 
 
 def test_rot(complex_coeffs, order):

--- a/tests/test_ducc0.py
+++ b/tests/test_ducc0.py
@@ -166,20 +166,26 @@ def test_real_forward_adjoint(rng: np.random.Generator, method, order):
 
     f_prime = rng.standard_normal(shape, dtype="float64")
     flm_prime = ssht.forward(f_prime, order, Reality=True, Method=method)
-    f_prime = ssht.forward_adjoint(flm_prime, order, Reality=True, Method=method, backend="ducc")
+    f_prime = ssht.forward_adjoint(
+        flm_prime, order, Reality=True, Method=method, backend="ducc"
+    )
 
     assert flm_prime.conj() @ flm == approx(f_prime.flatten().conj() @ f.flatten())
 
 
 @mark.parametrize("method", ["MW", "MWSS"])
 def test_forward_adjoint(rng: np.random.Generator, spin, method, order):
-    flm = rng.standard_normal((order * order, 2), dtype="float64") @ [1, 1j]
+    flm = rng.standard_normal((order * order, 2), dtype="float64") @ np.array([1, 1j])
     flm[0 : spin * spin] = 0.0
     f = ssht.inverse(flm, order, Spin=spin, Method=method, backend="ducc")
 
-    flm_prime = rng.standard_normal((order * order, 2), dtype="float64") @ [1, 1j]
+    flm_prime = rng.standard_normal((order * order, 2), dtype="float64") @ np.array(
+        [1, 1j]
+    )
     flm_prime[0 : spin * spin] = 0.0
-    f_prime = ssht.forward_adjoint(flm_prime, order, Spin=spin, Method=method, backend="ducc")
+    f_prime = ssht.forward_adjoint(
+        flm_prime, order, Spin=spin, Method=method, backend="ducc"
+    )
 
     assert flm_prime.conj() @ flm == approx(f_prime.flatten().conj() @ f.flatten())
 

--- a/typings/pyssht/__init__.pyi
+++ b/typings/pyssht/__init__.pyi
@@ -68,3 +68,9 @@ def rotate_flms(
     **kwargs,
 ) -> np.ndarray:
     pass
+
+def sample_length(L: int, Method: str = "MW") -> int:
+    pass
+
+def sample_shape(L: int, Method: str = "MW") -> Tuple[int, int]:
+    pass

--- a/typings/pyssht/__init__.pyi
+++ b/typings/pyssht/__init__.pyi
@@ -12,6 +12,17 @@ def forward(
 ) -> np.ndarray:
     pass
 
+def forward_adjoint(
+    flm: np.ndarray,
+    L: int,
+    Spin: int = 0,
+    Method: str = "MW",
+    Reality: bool = False,
+    backend: str = "SSHT",
+    **kwargs,
+) -> np.ndarray:
+    pass
+
 def inverse(
     flm: np.ndarray,
     L: int,


### PR DESCRIPTION
This PR adds all necessary machinery to allow `forward_adjoint` operations with `ducc0`.

Problem: `ssht` and `ducc0` currently produce different results when running `forward` on non-bandlimited maps, and so it is not entirely clear how to test the consistency between both implementations. We'll have to iterate on this a bit, I think.